### PR TITLE
creates new region where all js component templates will be rendered

### DIFF
--- a/themes/wilmap/lib/components/card.js
+++ b/themes/wilmap/lib/components/card.js
@@ -9,19 +9,13 @@ App.Component.Card = class Card {
     this.options = Object.assign({}, settings);
     this.el = $(`<div class="c-card ${this.options.extended ? '-extended' : ''}"></div>`);
 
-    this.template = `
-<p class="card-location">${this.options.location || 'location'}</p>
-<h3 class="card-heading">${this.options.heading || 'heading'}</h3>
-<h4 class="card-subheading">${this.options.subheading || 'subheading'}</h4>
-<p class="card-details">${this.options.details || 'details'}</p>
-<div class="card-content">${this.options.content}</div>
-`;
+    this.template = _.template($('#card-template').html());
 
     this.render();
   }
 
   render() {
-    this.el.html(this.template);
+    this.el.html(this.template(this.options));
   }
 
 };

--- a/themes/wilmap/templates/blocks/js-templates/block--cardtemplate.html.twig
+++ b/themes/wilmap/templates/blocks/js-templates/block--cardtemplate.html.twig
@@ -1,0 +1,7 @@
+<script type="text/template" id="card-template">
+  <p class="card-location"><%= location || 'location' %></p>
+  <h3 class="card-heading"><%= heading || 'heading' %></h3>
+  <h4 class="card-subheading"><%= subheading || 'subheading' %></h4>
+  <p class="card-details"><%= details || 'details' %></p>
+  <div class="card-content"><%= content %></div>
+</script>

--- a/themes/wilmap/templates/pages/explore/page--explore.html.twig
+++ b/themes/wilmap/templates/pages/explore/page--explore.html.twig
@@ -1,4 +1,5 @@
 {{ attach_library('wilmap/explore-js') }}
+{{ page.jsTemplates }}
 <div id="page-wrapper">
   <div id="page">
     <header id="header" class="header" role="banner" aria-label="{{ 'Site header'|t}}">

--- a/themes/wilmap/templates/pages/topics/page--topics.html.twig
+++ b/themes/wilmap/templates/pages/topics/page--topics.html.twig
@@ -1,4 +1,5 @@
 {{ attach_library('wilmap/topics-js') }}
+{{ page.jsTemplates }}
 <div id="page-wrapper">
   <div id="page">
     <header id="header" class="header" role="banner" aria-label="{{ 'Site header'|t}}">

--- a/themes/wilmap/wilmap.info.yml
+++ b/themes/wilmap/wilmap.info.yml
@@ -21,5 +21,6 @@ regions:
   contentMap: 'contentMap'
   contentAbout: 'contentAbout'
   footer: 'Footer'
+  jsTemplates: 'jsTemplates'
 
 features: true


### PR DESCRIPTION
This PR includes the following:
- Creates a new drupal region called jsTemplates that will contain all components' templates.
- Creates a new template for the card component.
- Includes the jsTemplates region in the topics and explore pages.